### PR TITLE
[WIP][DISCARDED] Fix container dependencies for init cmd

### DIFF
--- a/cmd/srcd/cmd/components.go
+++ b/cmd/srcd/cmd/components.go
@@ -42,7 +42,7 @@ var componentsListCmd = &cobra.Command{
 			return err
 		}
 
-		imgs, err := components.List(
+		imgs, err := components.ImageList(
 			context.Background(),
 			components.KnownComponents(daemonVersion, allVersions))
 		if err != nil {

--- a/cmd/srcd/daemon/daemon.go
+++ b/cmd/srcd/daemon/daemon.go
@@ -47,7 +47,9 @@ func DockerVersion() (string, error) { return docker.Version() }
 func IsRunning() (bool, error)       { return docker.IsRunning(daemonName) }
 
 func Kill() error {
-	cmps, err := components.List(context.Background(), components.IsWorkingDirDependant)
+	cmps, err := components.ContainerList(
+		context.Background(),
+		components.IsWorkingDirDependant)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Fix #60.

The code in  `Kill()` was there to stop the working directory dependencies, but somehow the image names and container names were mixed.
`Kill` needs container names for `RemoveContainer`, and `List` was returning image names. Besides that `KnownComponents` could not work because it was comparing image names to container names.